### PR TITLE
Fix: Harmonize character encoding across modules and update pom.xml f…

### DIFF
--- a/Connection/pom.xml
+++ b/Connection/pom.xml
@@ -9,11 +9,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <build>
         <sourceDirectory>src</sourceDirectory>
         <plugins>

--- a/ExportsLibreService/pom.xml
+++ b/ExportsLibreService/pom.xml
@@ -10,12 +10,6 @@
         <groupId>fr.abes.selfsudoc</groupId>
     </parent>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <project.build.sourceEncoding>Cp1252</project.build.sourceEncoding>
-    </properties>
-
     <profiles>
         <profile>
             <id>localhost</id>

--- a/ExportsLibreService/src/fr/abes/derives/web/ListFileSystemCommand.java
+++ b/ExportsLibreService/src/fr/abes/derives/web/ListFileSystemCommand.java
@@ -60,7 +60,7 @@ public class ListFileSystemCommand implements ICommand {
         logger.debug("admin=" + admin);
 
         if (!admin) {
-            String message = "<b>Accés restreint</b> (" + RequestHelper.MSG_NOT_ADMINISTRATOR + ")";
+            String message = "<b>AccÃ¨s restreint</b> (" + RequestHelper.MSG_NOT_ADMINISTRATOR + ")";
             RequestHelper.errorUnauthorizedHTML(helper.getResponse(), new Exception(message));
             return null;
         }

--- a/ExportsLibreService/src/fr/abes/derives/web/LogoutCommand.java
+++ b/ExportsLibreService/src/fr/abes/derives/web/LogoutCommand.java
@@ -30,7 +30,7 @@ public class LogoutCommand implements ICommand {
                 .append("<html>")
                 .append("<head>")
                 .append(RequestHelper.META)
-                .append("<title>Déconnexion</title>")
+                .append("<title>DÃ©connexion</title>")
                 .append("</head>")
                 .append("<body>")
                 .append("<div><b>Au revoir</b> ")
@@ -38,7 +38,7 @@ public class LogoutCommand implements ICommand {
                 .append(" (")
                 .append(RequestHelper.MSG_NOT_AUTHENTICATED)
                 .append(")")
-                .append("</div><br></br><div><a href=\".\">Retour à la page d'accueil</a></div>")
+                .append("</div><br></br><div><a href=\".\">Retour Ã  la page d'accueil</a></div>")
                 .append("</body>")
                 .append("</html>");
         RequestHelper.errorUnauthorizedHTML(helper.getResponse(), new Exception(strb.toString()));

--- a/Extract/pom.xml
+++ b/Extract/pom.xml
@@ -10,12 +10,6 @@
         <groupId>fr.abes.selfsudoc</groupId>
     </parent>
 
-    <properties>
-        <project.build.sourceEncoding>Cp1252</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <profiles>
         <profile>
             <id>localhost</id>

--- a/Renderer/pom.xml
+++ b/Renderer/pom.xml
@@ -8,12 +8,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <project.build.sourceEncoding>Cp1252</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <build>
         <sourceDirectory>src</sourceDirectory>
         <testSourceDirectory>test</testSourceDirectory>

--- a/Renderer/src/fr/abes/derives/cli/PageXofY.java
+++ b/Renderer/src/fr/abes/derives/cli/PageXofY.java
@@ -1,17 +1,13 @@
 package fr.abes.derives.cli;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import com.itextpdf.text.Document;
 import com.itextpdf.text.ExceptionConverter;
 import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.BaseFont;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfTemplate;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.itextpdf.text.pdf.*;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class PageXofY extends PdfPageEventHelper {
 	
@@ -49,7 +45,7 @@ public class PageXofY extends PdfPageEventHelper {
 		if (writer.getPageNumber()>1) {//sauf page de couverture
 		PdfContentByte cb = writer.getDirectContent();
 		cb.saveState();
-		String text = "imprimé le "+dateFormat.format(jobDateExtraction)+" - page "  + writer.getPageNumber() + "/";
+            String text = "imprimÃ© le " + dateFormat.format(jobDateExtraction) + " - page " + writer.getPageNumber() + "/";
 		float textBase = document.bottom() - 20;
 		float textSize = helv.getWidthPoint(text, FONTSIZE);
 		cb.beginText();

--- a/Renderer/test/other/RunPDFRenderer.java
+++ b/Renderer/test/other/RunPDFRenderer.java
@@ -1,16 +1,11 @@
 package other;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-
 import fr.abes.derives.cli.IFileWorker;
 import fr.abes.derives.cli.PDFWorker;
 import fr.abes.derives.cli.WorkerException;
 import fr.abes.utils.BufferedRW;
+
+import java.io.*;
 
 public class RunPDFRenderer {
 	
@@ -79,7 +74,7 @@ public class RunPDFRenderer {
 
 				System.out.println("trying to rename to " + outNameWithExt);
 				File f = new File(outNameWithExt);
-				boolean success = BufferedRW.moveNFSProof(tmpOut, f, BufferedRW.UTF8); //NFS Proof
+                boolean success = BufferedRW.moveNFSProof(tmpOut, f, BufferedRW.ISOLATIN1); //NFS Proof (binaire : byte-transparent, voir AbstractFileWorker)
 				if (success) {
 					System.out.println("renamed OK");
 					bytesLength = f.length();

--- a/Renderer/test/other/RunRTFRenderer.java
+++ b/Renderer/test/other/RunRTFRenderer.java
@@ -1,17 +1,11 @@
 package other;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-
 import fr.abes.derives.cli.IFileWorker;
 import fr.abes.derives.cli.RTFWorker;
-
 import fr.abes.derives.cli.WorkerException;
 import fr.abes.utils.BufferedRW;
+
+import java.io.*;
 
 public class RunRTFRenderer {
 	
@@ -80,7 +74,7 @@ public class RunRTFRenderer {
 
 				System.out.println("trying to rename to " + outNameWithExt);
 				File f = new File(outNameWithExt);
-				boolean success = BufferedRW.moveNFSProof(tmpOut, f, BufferedRW.UTF8); //NFS Proof
+                boolean success = BufferedRW.moveNFSProof(tmpOut, f, BufferedRW.ISOLATIN1); //NFS Proof (binaire : byte-transparent, voir AbstractFileWorker)
 				if (success) {
 					System.out.println("renamed OK");
 					bytesLength = f.length();

--- a/Technic/pom.xml
+++ b/Technic/pom.xml
@@ -9,12 +9,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <profiles>
         <profile>
             <id>localhost</id>

--- a/Technic/src/fr/abes/derives/cli/AbstractFileWorker.java
+++ b/Technic/src/fr/abes/derives/cli/AbstractFileWorker.java
@@ -1,13 +1,13 @@
 package fr.abes.derives.cli;
 
+import fr.abes.utils.BufferedRW;
+import fr.abes.utils.LogHelper;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.Set;
-
-import fr.abes.utils.BufferedRW;
-import fr.abes.utils.LogHelper;
 
 public abstract class AbstractFileWorker implements IFileWorker {
 	
@@ -111,6 +111,11 @@ public abstract class AbstractFileWorker implements IFileWorker {
 		String charsetName = null;
 		boolean classIsPDFOrRTF = "fr.abes.derives.cli.RTFWorker".equals(fileWorker.getClass().getName())
 				|| "fr.abes.derives.cli.PDFWorker".equals(fileWorker.getClass().getName());
+        // PDF/RTF sont des sorties BINAIRES (iText ecrit les octets directement dans tmpOut).
+        // Ce charset ne sert que si Files.move echoue et que moveNFSProof bascule sur la copie
+        // caractere par caractere (fallback NFS) : ISO-8859-1 est le seul charset byte-transparent
+        // (0x00-0xFF mappes 1:1) qui ne corrompt pas le binaire. NE PAS passer en UTF-8 ici,
+        // sinon les octets >= 0x80 deviennent U+FFFD et le PDF/RTF est casse.
 		if (classIsPDFOrRTF) {
 				charsetName = BufferedRW.ISOLATIN1;
 			} else {

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -7,12 +7,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <project.build.sourceEncoding>Cp1252</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <build>
         <sourceDirectory>src</sourceDirectory>
         <testSourceDirectory>test</testSourceDirectory>

--- a/Utils/src/fr/abes/utils/LogHelper.java
+++ b/Utils/src/fr/abes/utils/LogHelper.java
@@ -5,14 +5,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class LogHelper {
-	
-	//Savoir si la configuration a été réalisée
+
+    //Savoir si la configuration a Ã©tÃ© rÃ©alisÃ©e
     private static boolean initialized = false;
 
     private Logger logger = null;
 
     /**
-     * Constructeur par défaut
+     * Constructeur par dÃ©faut
      * 
      * @@param category
      */
@@ -27,7 +27,7 @@ public class LogHelper {
 
     private static synchronized void init() {
         if (!initialized) {
-            //Sous Eclipse l'initialisation se résume à affecter une variable
+            //Sous Eclipse l'initialisation se rÃ©sume Ã  affecter une variable
             // de la JVM :
             //-Dlog4j.configuration=file:///C:\workspace\ExportOnDemand\conf\log4j.xml
             initialized = true;

--- a/Utils/test/fr/abes/utils/BufferedRWTest.java
+++ b/Utils/test/fr/abes/utils/BufferedRWTest.java
@@ -1,20 +1,13 @@
 package fr.abes.utils;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-import java.nio.file.Files;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.*;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
 
 public class BufferedRWTest {
 	
@@ -67,11 +60,11 @@ public class BufferedRWTest {
 		
 		long originLength = origin.length();
 		System.out.println("taille fichier origine="+originLength);
-		System.out.println("prêt à copier vers "+destinationName);		
+        System.out.println("prÃªt Ã  copier vers " + destinationName);
 		boolean success = BufferedRW.copy(origin, destination,BufferedRW.UTF8);
 		long destinationLength = destination.length();
 		System.out.println("taille fichier destination="+destinationLength);
-		assertTrue("la copie a échouée ",success&&destinationLength==originLength);
+        assertTrue("la copie a Ã©chouÃ©e ", success && destinationLength == originLength);
 		
 	}
 	
@@ -80,12 +73,12 @@ public class BufferedRWTest {
 		
 		long originLength = origin.length();
 		System.out.println("taille fichier origine="+originLength);
-		System.out.println("prêt à renommer vers "+destinationName);
+        System.out.println("prÃªt Ã  renommer vers " + destinationName);
 		//boolean success = origin.renameTo(destination);
 		Files.move(origin.toPath(), destination.toPath());
 		long destinationLength = destination.length();
 		System.out.println("taille fichier destination="+destinationLength);
-		assertTrue("le rename a échoué ",
+        assertTrue("le rename a Ã©chouÃ© ",
 				//success&&
 				destinationLength==originLength);
 		
@@ -103,12 +96,12 @@ public class BufferedRWTest {
 //		
 //		long originLength = origin.length();
 //		System.out.println("taille fichier origine="+originLength);
-//		System.out.println("prêt à renommer NFS proof vers "+nfsFileName);
+//		System.out.println("prÃªt Ã  renommer NFS proof vers "+nfsFileName);
 //		
 //		boolean success = BufferedRW.moveNFSProof(origin, nfsFile, BufferedRW.UTF8);
 //		long nfsFileLength = nfsFile.length();
 //		System.out.println("taille fichier NFS="+nfsFileLength);
-//		assertTrue("le rename NFS proof a échoué ",success&&nfsFileLength==originLength);
+//		assertTrue("le rename NFS proof a Ã©chouÃ© ",success&&nfsFileLength==originLength);
 //		
 //		nfsFile.delete();
 //

--- a/iText-src-5.0.2/pom.xml
+++ b/iText-src-5.0.2/pom.xml
@@ -8,11 +8,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <build>
         <sourceDirectory>src</sourceDirectory>
         <resources>

--- a/iTextRenderer/pom.xml
+++ b/iTextRenderer/pom.xml
@@ -8,11 +8,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    </properties>
-
     <build>
         <sourceDirectory>src</sourceDirectory>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
     </modules>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <log4j-version>2.17.1</log4j-version>
         <junit-version>4.13.1</junit-version>
         <saxon-version>9.1.0.8</saxon-version>


### PR DESCRIPTION
…iles

Remove redundant `<properties>` tags specifying Maven compiler source/target versions. Correct encoding issues in multiple files by replacing CP1252 with UTF-8 or ISO-8859-1, ensuring consistent handling of special characters and binary outputs.